### PR TITLE
padding-top to avoid navbar above the content

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,6 +7,16 @@
     <link href="bootstrap/css/bootstrap.min.css" rel="stylesheet" media="screen">
     <link href="bootstrap/css/bootstrap-responsive.css" rel="stylesheet">
     <link href="css/styles.css" rel="stylesheet">
+    <style type="text/css">
+        body {
+          padding-top: 40px;
+        }
+        @media (max-width: 979px) {
+          body {
+            padding-top: 0px;
+          }
+        }
+    </style>
 
     <!-- HTML5 shim, for IE6-8 support of HTML5 elements -->
     <!--[if lt IE 9]>


### PR DESCRIPTION
without this you have navbar above the content, for example in contact
view you see image cut and "well" box cut.
with @media query works also in responsive.

sorry for my bad english :)
thanks for sharing this project!
